### PR TITLE
Check for bearer

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -40,7 +40,7 @@ myOAP.on('save_grant', function(req, client_id, code, next) {
 });
 
 // remove the grant when the access token has been sent
-myOAP.on('remove_grant', function(req, user_id, client_id, code) {
+myOAP.on('remove_grant', function(user_id, client_id, code) {
   if(myGrants[user_id] && myGrants[user_id][client_id])
     delete myGrants[user_id][client_id];
 });

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ OAuth2Provider.prototype.login = function() {
 
     if(req.query['access_token']) {
       atok = req.query['access_token'];
-    } else if(req.headers['authorization']) {
+    } else if(req.headers['authorization'] && req.headers['authorization'].indexOf('Bearer') == 0) {
       atok = req.headers['authorization'].replace('Bearer', '').trim();
     } else {
       return next();


### PR DESCRIPTION
As discussed in #6, add a stricter check for `Bearer` in the `Authorization` header.

Also fixed an issue in the `remove_grant` handler in the `simple.js` example.
