### PR TITLE
oauth2-provider does not work with connect 2.x, 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "index",
   "dependencies": {
-    "connect" : ">=1.6.0",
+    "connect" : ">=1.6.0 < 2",
     "serializer": ">=0.0.2"
   }
 }


### PR DESCRIPTION
which means this module currently does not work for anyone who uses npm to install oauth2-provider
