### PR TITLE
Fixed access token duplicate generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ OAuth2Provider.prototype.oauth = function() {
           if(self.listeners('save_access_token').length > 0)
             self.emit('save_access_token', user_id, client_id, atok);
 
-          res.end(JSON.stringify(self.generateAccessToken(user_id, client_id, extra_data)));
+          res.end(JSON.stringify(atok));
         });
 
         self.emit('remove_grant', user_id, client_id, code);


### PR DESCRIPTION
Access token is generated twice. 

First for save_access_token function and second for request response. Therefore token saved in the database differ from the one in the response.
