### PR TITLE
Adding support for sending extra parameters from 'create_access_token' into response data.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,29 @@
 
 var EventEmitter = require('events').EventEmitter,
      querystring = require('querystring'),
-      serializer = require('serializer'),
-      _ = require('underscore');
+      serializer = require('serializer');
 
+_extend = function(dst,src) {
+
+  var srcs = [];
+  if ( typeof(src) == 'object' ) {
+    srcs.push(src);
+  } else if ( typeof(src) == 'array' ) {
+    for (var i = src.length - 1; i >= 0; i--) {
+      srcs.push(this._extend({},src[i]))
+    };
+  } else {
+    throw new Error("Invalid argument")
+  }
+
+  for (var i = srcs.length - 1; i >= 0; i--) {
+    for (var key in srcs[i]) {
+      dst[key] = srcs[i][key];
+    }
+  };
+
+  return dst;
+}
 function parse_authorization(authorization) {
   if(!authorization)
     return null;
@@ -52,7 +72,7 @@ OAuth2Provider.prototype = new EventEmitter();
 
 OAuth2Provider.prototype.generateAccessToken = function(user_id, client_id, extra_data, token_options) {
   token_options = token_options || {}
-  var out = _.extend(token_options, {
+  var out = _extend(token_options, {
     access_token: this.serializer.stringify([user_id, client_id, +new Date, extra_data]),
     refresh_token: null,
   });

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@
 
 var EventEmitter = require('events').EventEmitter,
      querystring = require('querystring'),
-      serializer = require('serializer');
+      serializer = require('serializer'),
+      _ = require('underscore');
 
 function parse_authorization(authorization) {
   if(!authorization)
@@ -49,12 +50,12 @@ function OAuth2Provider(options) {
 
 OAuth2Provider.prototype = new EventEmitter();
 
-OAuth2Provider.prototype.generateAccessToken = function(user_id, client_id, extra_data) {
-  var out = {
+OAuth2Provider.prototype.generateAccessToken = function(user_id, client_id, extra_data, token_options) {
+  token_options = token_options || {}
+  var out = _.extend(token_options, {
     access_token: this.serializer.stringify([user_id, client_id, +new Date, extra_data]),
     refresh_token: null,
-  };
-
+  });
   return out;
 };
 
@@ -148,8 +149,8 @@ OAuth2Provider.prototype.oauth = function() {
             return res.end(e.message);
           }
 
-          self.emit('create_access_token', user_id, client_id, function(extra_data) {
-            var atok = self.generateAccessToken(user_id, client_id, extra_data);
+          self.emit('create_access_token', user_id, client_id, function(extra_data,token_options) {
+            var atok = self.generateAccessToken(user_id, client_id, extra_data, token_options);
 
             if(self.listeners('save_access_token').length > 0)
               self.emit('save_access_token', user_id, client_id, atok);
@@ -246,8 +247,8 @@ OAuth2Provider.prototype.oauth = function() {
 OAuth2Provider.prototype._createAccessToken = function(user_id, client_id, cb) {
   var self = this;
 
-  this.emit('create_access_token', user_id, client_id, function(extra_data) {
-    var atok = self.generateAccessToken(user_id, client_id, extra_data);
+  this.emit('create_access_token', user_id, client_id, function(extra_data, token_options) {
+    var atok = self.generateAccessToken(user_id, client_id, extra_data, token_options);
 
     if(self.listeners('save_access_token').length > 0)
       self.emit('save_access_token', user_id, client_id, atok);

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "main": "index",
   "dependencies": {
-    "serializer": ">=0.0.2 <0.1.0",
-    "underscore": "1.4.4"
+    "serializer": ">=0.0.2 <0.1.0"
   },
   "devDependencies": {
     "mocha" : "1.0.3"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "main": "index",
   "dependencies": {
-    "serializer": ">=0.0.2 <0.1.0"
+    "serializer": ">=0.0.2 <0.1.0",
+    "underscore": "1.4.4"
   },
   "devDependencies": {
     "mocha" : "1.0.3"


### PR DESCRIPTION
Added support for doing the following

```
myOAP.on('create_access_token', function(user_id, client_id, next) {
  next(null, {token_type: "bearer"});
});
```

Its fully backwards compatible.
